### PR TITLE
feat: css language mode server integration for TailwindCSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ npx tailwindcss init
 
 - `tailwindCSS.enable`: Enable coc-tailwindcss3 extension, default: `true`
 - `tailwindCSS.trace.server`: Trace level of tailwindCSS language server, default: `off`
+- `tailwindCSS-css-mode.trace.server`: Trace level of tailwindCSS CSS Mode language server, default: `""`
 - `tailwindCSS.custom.serverPath`: Custom path to server module. If there is no setting, the built-in module will be used, default: `""`
+- `tailwindCSS.custom.cssModeServerPath`: Custom path to css mode server module, default: `""`
 - `tailwindCSS.emmetCompletions`: Enable class name completions when using Emmet-style syntax, for example `div.bg-red-500.uppercase`, default: `false`
 - `tailwindCSS.includeLanguages`: Enable features in languages that are not supported by default. Add a mapping here between the new language and an already supported language. E.g.: `{"plaintext": "html"}`, default: `{ "eelixir": "html", "elixir": "html", "eruby": "html", "htmldjango": "html", "html.twig": "html" }`
 - `tailwindCSS.files.exclude`: Configure glob patterns to exclude from all IntelliSense features. Inherits all glob patterns from the `#files.exclude#` setting, default: ["**/.git/**", "**/node_modules/**", "**/.hg/**"]

--- a/package.json
+++ b/package.json
@@ -77,10 +77,25 @@
           ],
           "description": "Trace level of tailwindCSS language server"
         },
+        "tailwindCSS-css-mode.trace.server": {
+          "type": "string",
+          "default": "off",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "description": "Trace level of tailwindCSS CSS Mode language server"
+        },
         "tailwindCSS.custom.serverPath": {
           "type": "string",
           "default": "",
           "description": "Custom path to server module. If there is no setting, the built-in module will be used"
+        },
+        "tailwindCSS.custom.cssModeServerPath": {
+          "type": "string",
+          "default": "",
+          "description": "Custom path to css mode server module."
         },
         "tailwindCSS.emmetCompletions": {
           "type": "boolean",

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,10 @@ export function getConfigCustomServerPath() {
   return workspace.getConfiguration('tailwindCSS').get<string>('custom.serverPath', '');
 }
 
+export function getConfigCustomCssModeServerPath() {
+  return workspace.getConfiguration('tailwindCSS').get<string>('custom.cssModeServerPath', '');
+}
+
 export function getConfigExcludePatterns(): string[] {
   return workspace.getConfiguration('tailwindCSS').get<string[]>('files.exclude', []);
 }

--- a/src/util/languages.ts
+++ b/src/util/languages.ts
@@ -31,7 +31,7 @@ export const htmlLanguages = [
   'twig',
 ];
 
-export const cssLanguages = ['css', 'less', 'postcss', 'sass', 'scss', 'stylus', 'sugarss'];
+export const cssLanguages = ['css', 'less', 'postcss', 'sass', 'scss', 'stylus', 'sugarss', 'tailwindcss'];
 
 export const jsLanguages = ['javascript', 'javascriptreact', 'reason', 'rescript', 'typescript', 'typescriptreact'];
 


### PR DESCRIPTION
## Description

To edit css-related files, it is convenient to use `coc-css`. A language server with `vscode-css-languageservice` feature is started.

However, this language server has some minor problems, such as issuing warnings for TailwindCSS-specific syntax, etc. e.g. `@tailwind`, `@apply`, `@screen`, `@layer` and more.

To solve these problems, tailwindcss-intellisense seems to provide a dedicated css language server for TailwindCSS.

**REF**:

- https://github.com/tailwindlabs/tailwindcss-intellisense/blob/master/packages/vscode-tailwindcss/src/cssServer.ts

## Usage

### Prepare

**1**:

the language server module for this css requires `v0.8.0` or later of `vscode-tailwindcss`. Please check here for an example of using the server module installed with vsix.

- https://github.com/yaegassy/coc-tailwindcss3#usage-example-1-vsix
- https://github.com/yaegassy/coc-tailwindcss3#usage-example-2-use-extensions-installed-in-vscode

The npm package `@tailwindcss/language-server` does not yet include this server module.

Note: To be published in npm in the near future. <https://github.com/tailwindlabs/tailwindcss-intellisense/issues/536>

**2**:

Add the `g:coc_filetype_map` setting to your ".vimrc/init.vim". Add a configuration entry mapping the file type named `*.tailwindcss` to `tailwindcss`.

This is an example of the `css.tailwindcss` filetype. Of course, you can also use another css-related filetype, such as `scss.tailwindcss`.

```vim
let g:coc_filetype_map = {
 \ 'css.tailwindcss': 'tailwindcss',
 \ }
```

**3**:

Add `tailwindCSS.custom.cssModeServerPath` to `coc-settings.json`. The file path of the css server module must be set correctly for your environment.

```
{
  "tailwindCSS.custom.cssModeServerPath": "/path/to/tailwindcss-language-server/extension/dist/tailwindModeServer.js",
}
```

### Edit

1. Open the css-related file.
2. Change the filetype to `css.tailwindcss`.
    - `:set filetype=css.tailwindcss`
    - The css mode server provided by tailwindcss-intellisense starts up.