### PR TITLE
feat: dash force completions feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ See the coc.nvim wiki for more information.
 - `tailwindCSS.enable`: Enable coc-tailwindcss3 extension, default: `true`
 - `tailwindCSS.trace.server`: Trace level of tailwindCSS language server, default: `off`
 - `tailwindCSS.custom.serverPath`: Custom path to server module. If there is no setting, the built-in module will be used, default: `""`
+- `tailwindCSS.dashForceCompletions`: Enable dash (-) force completions feature, default: `true`
 - `tailwindCSS.emmetCompletions`: Enable class name completions when using Emmet-style syntax, for example `div.bg-red-500.uppercase`, default: `false`
 - `tailwindCSS.includeLanguages`: Enable features in languages that are not supported by default. Add a mapping here between the new language and an already supported language. E.g.: `{"plaintext": "html"}`, default: `{ "eelixir": "html", "elixir": "html", "eruby": "html", "htmldjango": "html", "html.twig": "html" }`
 - `tailwindCSS.files.exclude`: Configure glob patterns to exclude from all IntelliSense features. Inherits all glob patterns from the `#files.exclude#` setting, default: ["**/.git/**", "**/node_modules/**", "**/.hg/**"]

--- a/package.json
+++ b/package.json
@@ -86,6 +86,11 @@
           "default": "",
           "description": "Custom path to server module. If there is no setting, the built-in module will be used"
         },
+        "tailwindCSS.dashForceCompletions": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable dash (-) force completions feature"
+        },
         "tailwindCSS.emmetCompletions": {
           "type": "boolean",
           "default": false,

--- a/src/completions/dashForce.ts
+++ b/src/completions/dashForce.ts
@@ -1,0 +1,50 @@
+import {
+  CancellationToken,
+  CompletionContext,
+  CompletionItem,
+  CompletionItemProvider,
+  DocumentSelector,
+  ExtensionContext,
+  languages,
+  LinesTextDocument,
+  Position,
+  workspace,
+} from 'coc.nvim';
+
+export async function register(context: ExtensionContext, documentSelector: DocumentSelector) {
+  if (workspace.getConfiguration('tailwindCSS').get<boolean>('dashForceCompletions')) {
+    context.subscriptions.push(
+      languages.registerCompletionItemProvider(
+        'twcss3-dash',
+        'TWCSS3-DASH',
+        documentSelector,
+        new DashForceCompletionProvider(),
+        ['-']
+      )
+    );
+  }
+}
+
+export class DashForceCompletionProvider implements CompletionItemProvider {
+  async provideCompletionItems(
+    _document: LinesTextDocument,
+    _position: Position,
+    _token: CancellationToken,
+    context: CompletionContext
+  ): Promise<CompletionItem[]> {
+    if (context.triggerCharacter !== '-') return [];
+    const dummyItems: CompletionItem[] = [];
+
+    // MEMO: force completion
+    //
+    // There are a number of tailwindcss completion items that contain dash (-).
+    //
+    // When you type a "dash", the completion menu disappears, so you can avoid
+    // this problem by adding a "dash" with vim's `iskeyword` option
+    //
+    // However, Since coc.nvim v0.0.82, the `iskeyword` option in vim does not seem to be respected in completion.
+    workspace.nvim.call('coc#start');
+
+    return dummyItems;
+  }
+}


### PR DESCRIPTION
There are a number of tailwindcss completion items that contain "dash" (`-`). 

When you type a "dash", the completion menu disappears, so you can avoid this problem by adding a "dash" with vim's `iskeyword` option

However, Since coc.nvim v0.0.82, the `iskeyword` option in vim does not seem to be respected in completion.

Added the feature to "force completion" when entering "dash".