### PR TITLE
Remove tailwindCSS.headwind.sortTailwindClassesOnWorkspace command

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ See the coc.nvim wiki for more information.
 
 - `tailwindCSS.showOutput`: Tailwind CSS: Show Output
 - `tailwindCSS.headwind.sortTailwindClasses`: Headwind: Sort Tailwind CSS Classes
-- `tailwindCSS.headwind.sortTailwindClassesOnWorkspace`: Headwind: Sort Tailwind CSS Classes on Entire Workspace
 
 ## Custom Server Path
 

--- a/package.json
+++ b/package.json
@@ -1520,10 +1520,6 @@
       {
         "command": "tailwindCSS.headwind.sortTailwindClasses",
         "title": "Headwind: Sort Tailwind CSS Classes"
-      },
-      {
-        "command": "tailwindCSS.headwind.sortTailwindClassesOnWorkspace",
-        "title": "Headwind: Sort Tailwind CSS Classes on Entire Workspace"
       }
     ]
   },

--- a/src/headwind/headwindFeature.ts
+++ b/src/headwind/headwindFeature.ts
@@ -1,6 +1,4 @@
-import { spawn } from 'child_process';
-import { commands, ExtensionContext, OutputChannel, Range, Uri, window, workspace } from 'coc.nvim';
-import path from 'path';
+import { commands, ExtensionContext, OutputChannel, Range, workspace } from 'coc.nvim';
 import { buildMatchers, getTextMatch, sortClassString } from './headwindUtils';
 
 export type LangConfig =
@@ -76,34 +74,6 @@ export function activate(context: ExtensionContext, outputChannel: OutputChannel
     }
   });
 
-  const runOnProject = commands.registerCommand('tailwindCSS.headwind.sortTailwindClassesOnWorkspace', () => {
-    const workspaceFolder = workspace.workspaceFolders || [];
-    if (workspaceFolder[0]) {
-      const workspacePath = Uri.parse(workspaceFolder[0].uri).fsPath;
-      window.showInformationMessage(`Running Headwind on: ${workspacePath}`);
-
-      const rustyWindArgs = [workspacePath, '--write', shouldRemoveDuplicates ? '' : '--allow-duplicates'].filter(
-        (arg) => arg !== ''
-      );
-
-      const rustyWindBinPath = path.join(context.extensionPath, 'node_modules', '.bin', 'rustywind');
-      const rustyWindProc = spawn(rustyWindBinPath, rustyWindArgs);
-
-      rustyWindProc.stdout.on(
-        'data',
-        (data) => data && data.toString() !== '' && console.log('rustywind stdout:\n', data.toString())
-      );
-
-      rustyWindProc.stderr.on('data', (data) => {
-        if (data && data.toString() !== '') {
-          console.log('rustywind stderr:\n', data.toString());
-          window.showErrorMessage(`Headwind error: ${data.toString()}`);
-        }
-      });
-    }
-  });
-
-  context.subscriptions.push(runOnProject);
   context.subscriptions.push(disposable);
 
   // if runOnSave is enabled organize tailwind classes before saving


### PR DESCRIPTION
`tailwindCSS.headwind.sortTailwindClassesOnWorkspace` command is no longer working.

The current `:CocInstall` command seems to be caused by `--ignore-scripts` being set as an argument to `npm install`.

Close https://github.com/yaegassy/coc-tailwindcss3/issues/22