### PR TITLE
feat: add custom onRequest to @/tailwindCSS/getDocumentSymbols

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -229,6 +229,14 @@ export async function activate(context: ExtensionContext) {
     };
     const client = new LanguageClient('tailwindCSS', 'Tailwind CSS Language Server', serverOptions, clientOptions);
 
+    // MEMO: Define a dummy onRequest.
+    //
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    client.onRequest('@/tailwindCSS/getDocumentSymbols', async ({ uri }) => {
+      // MEMO: In coc.nvim, vscode.executeDocumentSymbolProvider is not provided by executeCommand.
+      //return commands.executeCommand<SymbolInformation[]>('vscode.executeDocumentSymbolProvider', Uri.parse(uri));
+    });
+
     client.start();
     clients.set(folder.uri.toString(), client);
   }


### PR DESCRIPTION
It seems that tailwindcss-language-server sometimes sends a custom request to `@/tailwindCSS/getDocumentSymbols` during auto-completion.

- <https://github.com/tailwindlabs/tailwindcss-intellisense/blob/c0d593a9aecabcfa2cf955fc59fb564329c8a39b/packages/tailwindcss-language-server/src/server.ts#L416-L418>

In that case, there seemed to be errors in the extension's functionality logs. 

```
[Error - 13:41:53.236] Sending request textDocument/completion failed.
  Message: Unhandled method @/tailwindCSS/getDocumentSymbols
  Code: -32601 
[Error - 13:41:53.236] Request textDocument/completion failed.
  Message: Unhandled method @/tailwindCSS/getDocumentSymbols
  Code: -32601 
```

Although basic functionality seems to work fine even if error logs appear on the backend, it was discovered that some functions do not work due to the impact of this error. Even with the `tailwindCSS.emmetCompletions` setting enabled, this feature does not seem to work properly with `jsx/tsx`.

Therefore, we will add a custom onRequest for `@/tailwindCSS/getDocumentSymbols` to the client-side. The processing is empty because it is added for the purpose of suppressing errors.

---

- Related issue
    - https://github.com/yaegassy/coc-tailwindcss3/issues/25