### PR TITLE
refactor: change the implementation to use normalize-path for Windows path

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@types/minimatch": "^3.0.5",
     "@types/node": "^18.15.11",
+    "@types/normalize-path": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^5.57.0",
     "@typescript-eslint/parser": "^5.57.0",
     "coc.nvim": "^0.0.82",
@@ -1526,6 +1527,7 @@
     "@tailwindcss/language-server": "^0.0.13",
     "fast-glob": "^3.2.11",
     "minimatch": "^5.0.1",
+    "normalize-path": "^3.0.0",
     "rustywind": "^0.7.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,13 @@ import {
   workspace,
   WorkspaceFolder,
 } from 'coc.nvim';
-import fg from 'fast-glob';
+
 import fs from 'fs';
-import minimatch from 'minimatch';
 import path from 'path';
+
+import fg from 'fast-glob';
+import minimatch from 'minimatch';
+import normalizePath from 'normalize-path';
 
 import { getConfigCustomServerPath, getConfigExcludePatterns, getConfigTailwindCssEnable } from './config';
 import { CONFIG_GLOB } from './constants';
@@ -190,15 +193,10 @@ export async function activate(context: ExtensionContext) {
     const languageObj = languages.get(folder.uri.toString());
     if (!languageObj) return;
 
-    const pattern =
-      process.platform === 'win32'
-        ? `${Uri.parse(folder!.uri).fsPath}/**/*`.replace('\\', '/')
-        : `${Uri.parse(folder!.uri).fsPath}/**/*`;
-
     const documentSelector = languageObj.map((language) => ({
       scheme: 'file',
       language,
-      pattern,
+      pattern: normalizePath(`${Uri.parse(folder!.uri).fsPath.replace(/[\[\]\{\}]/g, '?')}/**/*`),
     }));
 
     const clientOptions: LanguageClientOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -268,7 +268,7 @@ export async function activate(context: ExtensionContext) {
     try {
       const fgSource =
         process.platform === 'win32'
-          ? path.join(Uri.parse(folder.uri).fsPath, '**/' + CONFIG_GLOB).replace(/\\/, '/')
+          ? normalizePath(`${Uri.parse(folder.uri).fsPath.replace(/[\[\]\{\}]/g, '?')}/**/${CONFIG_GLOB}`)
           : path.join(Uri.parse(folder.uri).fsPath, '**/' + CONFIG_GLOB);
       const configFiles = await fg(fgSource, {
         ignore: getConfigExcludePatterns(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,6 +104,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.11.tgz#b3b790f09cb1696cffcec605de025b088fa4225f"
   integrity sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==
 
+"@types/normalize-path@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-path/-/normalize-path-3.0.0.tgz#bb5c46cab77b93350b4cf8d7ff1153f47189ae31"
+  integrity sha512-Nd8y/5t/7CRakPYiyPzr/IAfYusy1FkcZYFEAcoMZkwpJv2n4Wm+olW+e7xBdHEXhOnWdG9ddbar0gqZWS4x5Q==
+
 "@types/semver@^7.3.12":
   version "7.3.12"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.12.tgz#920447fdd78d76b19de0438b7f60df3c4a80bf1c"
@@ -879,6 +884,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+normalize-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
 once@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
I have made a change to use `normalize-path` like upstream `vscode-tailwindcss`.

- REF: <https://github.com/tailwindlabs/tailwindcss-intellisense/blob/460d921ca34fe7b52966a02dadb0a505f82fb3f7/packages/vscode-tailwindcss/src/extension.ts#L447>

---

Related issue: https://github.com/yaegassy/coc-tailwindcss3/issues/28